### PR TITLE
Balance parens in dev example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ namespace.
   (:require
    [com.stuartsierra.component :as component]
    [com.stuartsierra.component.repl
-     :refer [reset set-init start stop system])))
+     :refer [reset set-init start stop system]]))
 ```
 
 Provide an initializer function to


### PR DESCRIPTION
I caught this issue when copy-and-paste coding a new codebase today.